### PR TITLE
Fix broken eightshapes link

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -46,7 +46,7 @@
 
 
                             <div class="es-web-tool__external-links-wrap">
-                                <a class="es-web-tool__external-link es-web-tool__external-link--github" href="http://www.eightshapes.com/design-systems.html">
+                                <a class="es-web-tool__external-link es-web-tool__external-link--github" href="http://www.eightshapes.com">
                                     <span class="es-web-tool__external-link-text">
                                         By Eightshapes
                                     </span>


### PR DESCRIPTION
The link led to a github 404 page. The root page have links to the people behind eightshapes.